### PR TITLE
Define a default method for `IntoBody`

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -1,16 +1,5 @@
-// TODO: Implement more conversions.
-pub trait IntoBody {
-    fn into_body(self) -> Vec<u8>;
-}
-
-impl IntoBody for Vec<u8> {
+pub trait IntoBody: Into<Vec<u8>> {
     fn into_body(self) -> Vec<u8> {
-        self
-    }
-}
-
-impl<'a> IntoBody for &'a str {
-    fn into_body(self) -> Vec<u8> {
-        self.bytes().collect()
+        self.into()
     }
 }


### PR DESCRIPTION
`Into<Vec<u8>>` takes care of many of the cases where a user needs to convert
an existing datatype to a sequence of bytes. If a user needs to write custom
behavior, they now just need to implement `Into<Vec<u8>>`.

While this could be wholly supplanted by `Into<Vec<u8>>` and the `IntoBody`
trait could be removed, it's part of the public API and should not be removed
without a major version bump.