### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+dist: xenial
+
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+
+cache:
+  cargo: true
+
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true


### PR DESCRIPTION
This doesn't add any of the build badges, as @leoschwarz you'll have to enable things yourself on Travis before that.