### PR TITLE
Implement a proof of concept RocketClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 twox-hash = "1.1"
 url = "2.1"
+rocket = "^0.4"
 
 [dev-dependencies]
 futures = "0.1"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -76,3 +76,6 @@ pub use self::stub::{
 
 mod generic;
 pub use self::generic::GenericClient;
+
+mod rocket;
+pub use self::rocket::RocketClient;

--- a/src/client/rocket.rs
+++ b/src/client/rocket.rs
@@ -1,0 +1,83 @@
+use client::{Client, Response};
+use config::ClientConfig;
+use error::Error;
+use request::Request;
+use reqwest::header::HeaderMap;
+use reqwest::{StatusCode, Url};
+use rocket;
+use rocket::http::Method;
+use rocket::http::{ContentType, Status};
+use std::io::Read;
+
+pub struct RocketClient {
+    config: ClientConfig,
+    base_url: String,
+    test_client: rocket::local::Client,
+}
+
+impl RocketClient {
+    pub fn new(app: rocket::Rocket, base_url: String) -> Self {
+        RocketClient {
+            config: ClientConfig::default(),
+            base_url,
+            test_client: rocket::local::Client::new(app).unwrap(),
+        }
+    }
+}
+
+fn reqwest_method_to_rocket_method(method: reqwest::Method) -> Method {
+    match method {
+        reqwest::Method::GET => Method::Get,
+        reqwest::Method::PUT => Method::Put,
+        reqwest::Method::POST => Method::Post,
+        reqwest::Method::DELETE => Method::Delete,
+        reqwest::Method::OPTIONS => Method::Options,
+        reqwest::Method::HEAD => Method::Head,
+        reqwest::Method::TRACE => Method::Trace,
+        reqwest::Method::CONNECT => Method::Connect,
+        reqwest::Method::PATCH => Method::Patch,
+        _ => panic!(),
+    }
+}
+
+impl Client for RocketClient {
+    fn execute(&self, config: Option<&ClientConfig>, request: Request) -> Result<Response, Error> {
+        // Use internal config if none was provided together with the request.
+        // TODO: use the config
+        let config = config.unwrap_or_else(|| &self.config);
+        let path = match request.header.url.as_str().strip_prefix(&self.base_url) {
+            Some(path) => path,
+            None => {
+                return Ok(Response {
+                    url: request.header.url,
+                    status: StatusCode::NOT_FOUND,
+                    headers: HeaderMap::new(),
+                    body: vec![],
+                })
+            }
+        };
+        let mut local_response = self
+            .test_client
+            .req(reqwest_method_to_rocket_method(request.header.method), path)
+            .dispatch();
+        let status = match local_response.status() {
+            Status::Ok => StatusCode::OK,
+            Status::NotFound => StatusCode::NOT_FOUND,
+            _ => panic!(),
+        };
+        Ok(Response {
+            url: request.header.url.clone(),
+            status: status,
+            headers: HeaderMap::new(),
+            body: local_response.body_bytes().unwrap_or(vec![]),
+        })
+    }
+
+    fn config(&self) -> &ClientConfig {
+        &self.config
+    }
+
+    fn config_mut(&mut self) -> &mut ClientConfig {
+        &mut self.config
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ extern crate http;
 #[macro_use]
 extern crate log;
 extern crate reqwest;
+#[macro_use]
+extern crate rocket;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/tests/rocket.rs
+++ b/tests/rocket.rs
@@ -1,0 +1,37 @@
+#![feature(proc_macro_hygiene, decl_macro)]
+
+#[macro_use]
+extern crate rocket;
+
+use rocket::http::{ContentType, Status};
+
+extern crate reqwest_mock;
+
+use reqwest_mock::client::RocketClient;
+use reqwest_mock::{Client, StatusCode};
+
+#[get("/")]
+fn index() -> &'static str {
+    "Yes, this is index"
+}
+
+fn rocket() -> rocket::Rocket {
+    rocket::ignite().mount("/", routes![index])
+}
+
+#[test]
+fn test_index() {
+    let client = RocketClient::new(rocket(), "http://some.site".to_string());
+
+    // Good request
+    let response = client.get("http://some.site").send().unwrap();
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.body_to_utf8().unwrap(), "Yes, this is index");
+
+    // Bad requests
+    let response = client.get("http://some.site/path/whatever").send().unwrap();
+    assert_eq!(response.status, StatusCode::NOT_FOUND);
+
+    let response = client.get("http://bad.domain").send().unwrap();
+    assert_eq!(response.status, StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
Hey,

Just to get this out of the way: this is not a PR I'd want to merge just yet, it's more of a proof of concept and a quick and dirty piece of code to explore the possibilities.

I found this repository after doing some research on how people test code using `reqwest`, mainly this discussion: https://github.com/seanmonstar/reqwest/issues/154

Contrary to what I read there and in another discussion in this repository (https://github.com/leoschwarz/reqwest_mock/issues/30) I remain convinced that `wiremock` is not quite what I want and `reqwest_mock` is almost exactly the way things should be done.

I agree with #30 in that we could use a bit more dynamism than `StubClient` or `ReplayClient`, hance my stab at it: wrapping a `rocket` application through its test client and dispatching requests to it. I have no experience with `rocket` in particular, I just grabbed whatever's popular out there, it should be possible to adapt this to any other framework with a test client provided.

What do you think? If this approach seems viable I'm happy to clean this up, put the `rocket` dependency behind a feature flag, implement the missing pieces etc.